### PR TITLE
feat: add configurable position_center_steps for [-π, π) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ This node is recommended for all robots using STS motors to ensure safe operatio
 | `operating_mode` | int | 1 | 0=Position (closed-loop), 1=Velocity (closed-loop), 2=PWM (open-loop) |
 | `min_position` | double | 0.0 | Min position limit (radians, Mode 0 only) |
 | `max_position` | double | 6.283 | Max position limit (2π radians, Mode 0 only) |
+| `position_center_steps` | int | 4095 | Raw encoder step mapped to 0 rad, 0–4095 (Mode 0 only). Default gives [0, 2π) range; set to 2048 for approximately [−π, +π] range. |
 | `max_velocity` | double | 5.22 | Max velocity limit (rad/s, Modes 0 and 1, optional) |
 | `max_effort` | double | 1.0 | Maximum allowed effort command ((0.0, 1.0], Mode 2 only). Safety limiter that restricts command range without scaling. |
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -172,6 +172,7 @@ Configure these per `<joint>` in your URDF:
 | `operating_mode` | int | 1 | 0, 1, 2 | 0=Position, 1=Velocity, 2=PWM |
 | `min_position` | double | 0.0 | any | Min position limit (radians, Mode 0 only) |
 | `max_position` | double | 6.283 | any | Max position limit (radians, Mode 0 only) |
+| `position_center_steps` | int | 4095 | 0–4095 | Raw encoder step mapped to 0 rad (Mode 0 only). Default gives [0, 2π) range; set to 2048 for approximately [−π, +π] range. |
 | `max_velocity` | double | 5.22 | > 0.0 | Max velocity limit (rad/s, Modes 0 and 1) |
 | `max_effort` | double | 1.0 | (0.0, 1.0] | Maximum allowed effort command (Mode 2 only). Limits command range without scaling. |
 
@@ -389,9 +390,9 @@ This inversion is transparent to controllers - they always work with REP-103 com
 
 ### Position Conversion
 - **Motor units:** 0-4095 steps (12-bit resolution)
-- **ROS 2 units:** 0-2π radians (one full revolution)
-- **Conversion:** `radians = (4095 - steps) × (2π / 4096)` — includes REP-103 direction inversion (raw 0 → ~2π, raw 4095 → 0)
-- **Note:** Position wraps at 2π (4096 steps)
+- **ROS 2 units:** Depends on `position_center_steps`: default (4095) gives [0, 2π), center=2048 gives approximately [−π, +π]
+- **Conversion:** `radians = (center - steps) × (2π / 4096)` — includes REP-103 direction inversion; `center` defaults to 4095 (configurable per joint via `position_center_steps`)
+- **Note:** Commands outside the encoder range are clamped to [0, 4095] steps (not wrapped)
 
 ### Velocity Conversion
 - **Motor units:** ±3400 steps/s maximum

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -395,9 +395,10 @@ Edit `config/motor_diagnostics_config.yaml` to set warning/error levels for volt
    <param name="max_velocity">5.22</param>   <!-- rad/s, optional -->
    ```
 
-2. **Check for position wrapping:**
-   - STS motors wrap at 2π radians (4096 steps)
-   - Ensure mechanism doesn't require >2π range
+2. **Check position range:**
+   - Default range is [0, 2π) radians (center at step 4095)
+   - For [−π, +π] range, set `position_center_steps: 2048` in joint parameters
+   - Commands outside the encoder range are clamped (not wrapped)
 
 3. **Monitor encoder values:**
    ```bash

--- a/include/sts_hardware_interface/sts_conversions.hpp
+++ b/include/sts_hardware_interface/sts_conversions.hpp
@@ -23,7 +23,7 @@ constexpr double STEPS_PER_REVOLUTION = 4096.0;
 constexpr double STEPS_TO_RAD = (2.0 * M_PI) / STEPS_PER_REVOLUTION;
 constexpr double RAD_TO_STEPS = STEPS_PER_REVOLUTION / (2.0 * M_PI);
 constexpr int    STS_MAX_POSITION     = 4095;   // 12-bit encoder
-constexpr int    STS_DEFAULT_CENTER   = 4095;   // Default: 0 rad at step 4095, range [0, 2π]
+constexpr int    STS_DEFAULT_CENTER   = 4095;   // Default: 0 rad at step 4095, range [0, 2π)
 constexpr int    STS_MAX_PWM          = 1000;   // ±100% duty cycle
 constexpr int    STS_MAX_ACCELERATION = 254;    // protocol constant
 

--- a/include/sts_hardware_interface/sts_conversions.hpp
+++ b/include/sts_hardware_interface/sts_conversions.hpp
@@ -23,33 +23,30 @@ constexpr double STEPS_PER_REVOLUTION = 4096.0;
 constexpr double STEPS_TO_RAD = (2.0 * M_PI) / STEPS_PER_REVOLUTION;
 constexpr double RAD_TO_STEPS = STEPS_PER_REVOLUTION / (2.0 * M_PI);
 constexpr int    STS_MAX_POSITION     = 4095;   // 12-bit encoder
+constexpr int    STS_DEFAULT_CENTER   = 4095;   // Default: 0 rad at step 4095, range [0, 2π]
 constexpr int    STS_MAX_PWM          = 1000;   // ±100% duty cycle
 constexpr int    STS_MAX_ACCELERATION = 254;    // protocol constant
 
 /**
- * @brief Convert motor steps [0, 4095] to radians [0, 2π] with direction inversion.
+ * @brief Convert motor steps [0, 4095] to radians with configurable center.
  *
  * STS motors increment clockwise; ROS 2 uses counter-clockwise positive (REP-103).
- * Direction is inverted by mapping: raw 0 → ~2π, raw 4095 → 0.
+ * `center` is the raw encoder step that maps to 0 rad (default: STS_DEFAULT_CENTER = 4095).
  */
-inline double raw_position_to_radians(int raw_position)
+inline double raw_position_to_radians(int raw_position, int center = STS_DEFAULT_CENTER)
 {
-  return static_cast<double>(STS_MAX_POSITION - raw_position) * STEPS_TO_RAD;
+  return static_cast<double>(center - raw_position) * STEPS_TO_RAD;
 }
 
 /**
- * @brief Convert radians [0, 2π] to motor steps [0, 4095] with direction inversion.
+ * @brief Convert radians to motor steps [0, 4095] with configurable center.
  *
- * Wraps the input modulo 2π before converting. The negative sign inside fmod
- * implements the same direction inversion as raw_position_to_radians.
+ * `center` is the raw encoder step that maps to 0 rad (default: STS_DEFAULT_CENTER = 4095).
+ * Values outside the physical encoder range are clamped to [0, 4095].
  */
-inline int radians_to_raw_position(double position_rad)
+inline int radians_to_raw_position(double position_rad, int center = STS_DEFAULT_CENTER)
 {
-  double normalized = std::fmod(-position_rad, 2.0 * M_PI);
-  if (normalized < 0.0) {
-    normalized += 2.0 * M_PI;
-  }
-  int raw = static_cast<int>(normalized * RAD_TO_STEPS);
+  int raw = static_cast<int>(std::round(center - position_rad * RAD_TO_STEPS));
   return std::clamp(raw, 0, STS_MAX_POSITION);
 }
 

--- a/include/sts_hardware_interface/sts_conversions.hpp
+++ b/include/sts_hardware_interface/sts_conversions.hpp
@@ -42,12 +42,14 @@ inline double raw_position_to_radians(int raw_position, int center = STS_DEFAULT
  * @brief Convert radians to motor steps [0, 4095] with configurable center.
  *
  * `center` is the raw encoder step that maps to 0 rad (default: STS_DEFAULT_CENTER = 4095).
- * Values outside the physical encoder range are clamped to [0, 4095].
+ * Values outside the physical encoder range are clamped (not wrapped) to [0, 4095].
+ * Clamping is intentional: the old fmod-based wrapping silently mapped negative
+ * angles to the wrong end of the encoder, causing full-revolution traversals.
  */
 inline int radians_to_raw_position(double position_rad, int center = STS_DEFAULT_CENTER)
 {
-  int raw = static_cast<int>(std::round(center - position_rad * RAD_TO_STEPS));
-  return std::clamp(raw, 0, STS_MAX_POSITION);
+  double steps = std::round(static_cast<double>(center) - position_rad * RAD_TO_STEPS);
+  return static_cast<int>(std::clamp(steps, 0.0, static_cast<double>(STS_MAX_POSITION)));
 }
 
 /**

--- a/include/sts_hardware_interface/sts_hardware_interface.hpp
+++ b/include/sts_hardware_interface/sts_hardware_interface.hpp
@@ -77,9 +77,10 @@ namespace sts_hardware_interface
  * - operating_mode: 0=servo, 1=velocity, 2=PWM (default: 1)
  * - min_position: Minimum position limit in radians (default: 0.0)
  * - max_position: Maximum position limit in radians (default: 6.283, 2π)
- * - position_center_steps: Raw encoder step that maps to 0 rad, 0-4095 or -1 for default
+ * - position_center_steps: Raw encoder step that maps to 0 rad, 0-4095
  *                          (default: 4095). Only used in position mode (mode 0). Set to your
- *                          servo's calibrated center; e.g. 2048 for [-π, +π] range.
+ *                          servo's calibrated center; e.g. 2048 for approximately [-π, +π]
+ *                          range (one encoder step of asymmetry at the ±π boundary).
  * - max_velocity: Maximum velocity limit in rad/s (default: 5.22, STS3215 max: 3400 steps/s)
  *                 NOTE: Adjust this for other STS motors (e.g., STS3032 max: 2900 steps/s)
  * - max_effort: Maximum effort limit, 0-1 for PWM mode (default: 1.0)

--- a/include/sts_hardware_interface/sts_hardware_interface.hpp
+++ b/include/sts_hardware_interface/sts_hardware_interface.hpp
@@ -77,6 +77,9 @@ namespace sts_hardware_interface
  * - operating_mode: 0=servo, 1=velocity, 2=PWM (default: 1)
  * - min_position: Minimum position limit in radians (default: 0.0)
  * - max_position: Maximum position limit in radians (default: 6.283, 2π)
+ * - position_center_steps: Raw encoder step that maps to 0 rad, 0-4095 or -1 for default
+ *                          (default: 4095). Only used in position mode (mode 0). Set to your
+ *                          servo's calibrated center; e.g. 2048 for [-π, +π] range.
  * - max_velocity: Maximum velocity limit in rad/s (default: 5.22, STS3215 max: 3400 steps/s)
  *                 NOTE: Adjust this for other STS motors (e.g., STS3032 max: 2900 steps/s)
  * - max_effort: Maximum effort limit, 0-1 for PWM mode (default: 1.0)
@@ -218,6 +221,7 @@ private:
   std::vector<bool> has_position_limits_;
   std::vector<bool> has_velocity_limits_;
   std::vector<bool> has_effort_limits_;
+  std::vector<int> position_center_;  // Raw step for 0 rad per joint (default: STS_DEFAULT_CENTER=4095)
 
   // ===== ERROR TRACKING =====
   int consecutive_read_errors_;

--- a/src/sts_hardware_interface.cpp
+++ b/src/sts_hardware_interface.cpp
@@ -211,6 +211,7 @@ hardware_interface::CallbackReturn STSHardwareInterface::on_init(
   has_position_limits_.resize(num_joints, false);
   has_velocity_limits_.resize(num_joints, false);
   has_effort_limits_.resize(num_joints, false);
+  position_center_.resize(num_joints, conversions::STS_DEFAULT_CENTER);  // 4095 = legacy default
 
   // Parse each joint
   for (size_t i = 0; i < num_joints; ++i) {
@@ -284,6 +285,31 @@ hardware_interface::CallbackReturn STSHardwareInterface::on_init(
       RCLCPP_ERROR(logger_, "Joint '%s': min_position (%.3f) must be less than max_position (%.3f)",
         joint.name.c_str(), position_min_[i], position_max_[i]);
       return hardware_interface::CallbackReturn::ERROR;
+    }
+
+    if (joint.parameters.count("position_center_steps")) {
+      if (operating_modes_[i] != MODE_SERVO) {
+        RCLCPP_WARN(logger_, "Joint '%s': position_center_steps is ignored in operating mode %d (only used in position mode %d)",
+          joint.name.c_str(), operating_modes_[i], MODE_SERVO);
+      } else {
+        try {
+          int center = std::stoi(joint.parameters.at("position_center_steps"));
+          if (center < -1 || center > conversions::STS_MAX_POSITION) {
+            RCLCPP_ERROR(logger_, "Joint '%s': position_center_steps %d out of range (-1 to disable, or [0, 4095])",
+              joint.name.c_str(), center);
+            return hardware_interface::CallbackReturn::ERROR;
+          }
+          if (center == -1) {
+            position_center_[i] = conversions::STS_DEFAULT_CENTER;  // -1 explicitly means legacy 4095
+          } else {
+            position_center_[i] = center;
+          }
+        } catch (const std::exception &) {
+          RCLCPP_ERROR(logger_, "Joint '%s': Invalid position_center_steps value: '%s'",
+            joint.name.c_str(), joint.parameters.at("position_center_steps").c_str());
+          return hardware_interface::CallbackReturn::ERROR;
+        }
+      }
     }
 
     if (joint.parameters.count("max_velocity")) {
@@ -764,7 +790,7 @@ hardware_interface::return_type STSHardwareInterface::read(
 
     // Read all state interfaces
     int raw_position = servo_->ReadPos(-1);
-    hw_state_position_[i] = conversions::raw_position_to_radians(raw_position);
+    hw_state_position_[i] = conversions::raw_position_to_radians(raw_position, position_center_[i]);
 
     int raw_velocity = servo_->ReadSpeed(-1);
     hw_state_velocity_[i] = conversions::raw_velocity_to_rad_s(raw_velocity);
@@ -866,7 +892,7 @@ hardware_interface::return_type STSHardwareInterface::write(
       for (size_t j = 0; j < servo_motor_indices_.size(); ++j) {
         size_t idx = servo_motor_indices_[j];
         double target_position = conversions::apply_limit(hw_cmd_position_[idx], position_min_[idx], position_max_[idx], has_position_limits_[idx]);
-        servo_sync_positions_[j] = conversions::radians_to_raw_position(target_position);
+        servo_sync_positions_[j] = conversions::radians_to_raw_position(target_position, position_center_[idx]);
         servo_sync_deltas_[j] = std::abs(target_position - hw_state_position_[idx]);
         max_delta_rad = std::max(max_delta_rad, servo_sync_deltas_[j]);
         servo_sync_accelerations_[j] = static_cast<u8>(conversions::clamp_acceleration(hw_cmd_acceleration_[idx]));
@@ -905,7 +931,7 @@ hardware_interface::return_type STSHardwareInterface::write(
         double target_position = conversions::apply_limit(hw_cmd_position_[idx], position_min_[idx], position_max_[idx], has_position_limits_[idx]);
         double max_speed = conversions::apply_limit(hw_cmd_velocity_[idx], 0.0, velocity_max_[idx], has_velocity_limits_[idx]);
 
-        int raw_position = conversions::radians_to_raw_position(target_position);
+        int raw_position = conversions::radians_to_raw_position(target_position, position_center_[idx]);
         // rad_s_to_raw_speed: unsigned magnitude conversion for position mode — no sign inversion.
         // hw_cmd_velocity_ == 0.0 (not declared / not written) → raw 0 = STS protocol max speed.
         int raw_max_speed = conversions::rad_s_to_raw_speed(

--- a/src/sts_hardware_interface.cpp
+++ b/src/sts_hardware_interface.cpp
@@ -294,16 +294,12 @@ hardware_interface::CallbackReturn STSHardwareInterface::on_init(
       } else {
         try {
           int center = std::stoi(joint.parameters.at("position_center_steps"));
-          if (center < -1 || center > conversions::STS_MAX_POSITION) {
-            RCLCPP_ERROR(logger_, "Joint '%s': position_center_steps %d out of range (-1 to disable, or [0, 4095])",
+          if (center < 0 || center > conversions::STS_MAX_POSITION) {
+            RCLCPP_ERROR(logger_, "Joint '%s': position_center_steps %d out of range [0, 4095]",
               joint.name.c_str(), center);
             return hardware_interface::CallbackReturn::ERROR;
           }
-          if (center == -1) {
-            position_center_[i] = conversions::STS_DEFAULT_CENTER;  // -1 explicitly means legacy 4095
-          } else {
-            position_center_[i] = center;
-          }
+          position_center_[i] = center;
         } catch (const std::exception &) {
           RCLCPP_ERROR(logger_, "Joint '%s': Invalid position_center_steps value: '%s'",
             joint.name.c_str(), joint.parameters.at("position_center_steps").c_str());

--- a/test/test_conversions.cpp
+++ b/test/test_conversions.cpp
@@ -32,9 +32,7 @@ TEST(ConversionsTest, RawPositionToRadians_KnownValues) {
 }
 
 TEST(ConversionsTest, RawPositionToRadians_Roundtrip) {
-  // raw_position_to_radians uses STS_MAX_POSITION=4095 while radians_to_raw_position
-  // uses STEPS_PER_REVOLUTION=4096, producing a systematic +1 offset on the inverse path.
-  // The roundtrip is therefore lossy by exactly 1 step for most values.
+  // With the unified formula, roundtrip error is ≤1 step (quantization only).
   for (int raw = 0; raw <= 4095; raw += 100) {
     double rad = raw_position_to_radians(raw);
     int recovered = radians_to_raw_position(rad);
@@ -45,8 +43,8 @@ TEST(ConversionsTest, RawPositionToRadians_Roundtrip) {
 // ---- radians_to_raw_position ----
 
 TEST(ConversionsTest, RadiansToRawPosition_Zero) {
-  // 0 radians → raw=0: fmod(-0.0, 2π)=0, so 0 * RAD_TO_STEPS = 0
-  EXPECT_EQ(radians_to_raw_position(0.0), 0);
+  // 0 rad maps to center step (4095 by default)
+  EXPECT_EQ(radians_to_raw_position(0.0), 4095);
 }
 
 TEST(ConversionsTest, RadiansToRawPosition_StaysInRange) {
@@ -250,6 +248,41 @@ TEST(ConversionsTest, RadSToRawSpeed_NoSignInversionContrastWithVelocity) {
   EXPECT_LT(vel_raw, 0);          // velocity: sign-inverted → negative
   EXPECT_GT(spd_raw, 0);          // speed: unsigned magnitude → positive
   EXPECT_EQ(-vel_raw, spd_raw);   // same magnitude
+}
+
+// ---- custom center ----
+
+TEST(ConversionsTest, CustomCenter_KnownValues) {
+  // read: center=2048 maps step 2048 → 0 rad
+  EXPECT_NEAR(raw_position_to_radians(2048, 2048), 0.0, 1e-6);
+  EXPECT_NEAR(raw_position_to_radians(0,    2048), 2048.0 * (2.0 * M_PI / 4096.0), 1e-6);
+  EXPECT_NEAR(raw_position_to_radians(4095, 2048), -2047.0 * (2.0 * M_PI / 4096.0), 1e-6);
+  // write: 0 rad → step 2048
+  EXPECT_EQ(radians_to_raw_position(0.0, 2048), 2048);
+  EXPECT_NEAR(radians_to_raw_position( 2.0, 2048), 744,  1);
+  EXPECT_NEAR(radians_to_raw_position(-2.0, 2048), 3352, 1);
+  // -0.1 rad → step 2113 (short path from center, NOT wrapping around)
+  EXPECT_NEAR(radians_to_raw_position(-0.1, 2048), 2113, 1);
+  EXPECT_EQ(  radians_to_raw_position( M_PI, 2048), 0);     // clamped
+  EXPECT_EQ(  radians_to_raw_position(-M_PI, 2048), 4095);  // clamped
+}
+
+TEST(ConversionsTest, CustomCenter_RoundtripAndClamping) {
+  // roundtrip with center=2048
+  for (double rad : {-2.0, -1.0, -0.1, 0.0, 0.1, 1.0, 2.0}) {
+    int raw = radians_to_raw_position(rad, 2048);
+    double recovered = raw_position_to_radians(raw, 2048);
+    EXPECT_NEAR(recovered, rad, 2.0 * M_PI / 4096.0 + 1e-9)
+      << "Roundtrip error too large at rad=" << rad;
+  }
+  // output always clamped to [0, 4095] for any center
+  for (int center : {0, 1000, 2048, 3000, 4095}) {
+    for (double rad : {-M_PI, 0.0, M_PI, 100.0, -100.0}) {
+      int result = radians_to_raw_position(rad, center);
+      EXPECT_GE(result, 0) << "out of range for center=" << center << ", rad=" << rad;
+      EXPECT_LE(result, 4095) << "out of range for center=" << center << ", rad=" << rad;
+    }
+  }
 }
 
 int main(int argc, char ** argv)

--- a/test/test_hardware_interface.cpp
+++ b/test/test_hardware_interface.cpp
@@ -353,6 +353,56 @@ TEST(HardwareInterfaceInitTest, ZeroMaxEffortReturnsError) {
   EXPECT_EQ(hw.on_init(info), CallbackReturn::ERROR);
 }
 
+// ---- on_init: position_center_steps validation ----
+
+TEST(HardwareInterfaceInitTest, PositionCenterStepsValidValues) {
+  // center=2048 in servo mode succeeds
+  sts_hardware_interface::STSHardwareInterface hw1;
+  auto info1 = make_valid_position_motor_info();
+  info1.joints[0].parameters["position_center_steps"] = "2048";
+  EXPECT_EQ(hw1.on_init(info1), CallbackReturn::SUCCESS);
+
+  // -1 (explicit legacy default) also succeeds
+  sts_hardware_interface::STSHardwareInterface hw2;
+  auto info2 = make_valid_position_motor_info();
+  info2.joints[0].parameters["position_center_steps"] = "-1";
+  EXPECT_EQ(hw2.on_init(info2), CallbackReturn::SUCCESS);
+}
+
+TEST(HardwareInterfaceInitTest, PositionCenterStepsInvalidValues) {
+  // out of range (> 4095)
+  sts_hardware_interface::STSHardwareInterface hw1;
+  auto info1 = make_valid_position_motor_info();
+  info1.joints[0].parameters["position_center_steps"] = "5000";
+  EXPECT_EQ(hw1.on_init(info1), CallbackReturn::ERROR);
+
+  // out of range (< -1)
+  sts_hardware_interface::STSHardwareInterface hw2;
+  auto info2 = make_valid_position_motor_info();
+  info2.joints[0].parameters["position_center_steps"] = "-2";
+  EXPECT_EQ(hw2.on_init(info2), CallbackReturn::ERROR);
+
+  // non-numeric string
+  sts_hardware_interface::STSHardwareInterface hw3;
+  auto info3 = make_valid_position_motor_info();
+  info3.joints[0].parameters["position_center_steps"] = "abc";
+  EXPECT_EQ(hw3.on_init(info3), CallbackReturn::ERROR);
+}
+
+TEST(HardwareInterfaceInitTest, PositionCenterStepsIgnoredInNonServoModes) {
+  // velocity mode (1): succeeds with warning
+  sts_hardware_interface::STSHardwareInterface hw1;
+  auto info1 = make_valid_single_motor_info("/dev/ttyACM0", "1", "1");
+  info1.joints[0].parameters["position_center_steps"] = "2048";
+  EXPECT_EQ(hw1.on_init(info1), CallbackReturn::SUCCESS);
+
+  // PWM mode (2): succeeds with warning
+  sts_hardware_interface::STSHardwareInterface hw2;
+  auto info2 = make_valid_effort_motor_info();
+  info2.joints[0].parameters["position_center_steps"] = "2048";
+  EXPECT_EQ(hw2.on_init(info2), CallbackReturn::SUCCESS);
+}
+
 // ---- export_state_interfaces ----
 
 TEST(HardwareInterfaceExportTest, StateInterfacesCount) {

--- a/test/test_hardware_interface.cpp
+++ b/test/test_hardware_interface.cpp
@@ -362,11 +362,17 @@ TEST(HardwareInterfaceInitTest, PositionCenterStepsValidValues) {
   info1.joints[0].parameters["position_center_steps"] = "2048";
   EXPECT_EQ(hw1.on_init(info1), CallbackReturn::SUCCESS);
 
-  // -1 (explicit legacy default) also succeeds
+  // boundary: 0 succeeds
   sts_hardware_interface::STSHardwareInterface hw2;
   auto info2 = make_valid_position_motor_info();
-  info2.joints[0].parameters["position_center_steps"] = "-1";
+  info2.joints[0].parameters["position_center_steps"] = "0";
   EXPECT_EQ(hw2.on_init(info2), CallbackReturn::SUCCESS);
+
+  // boundary: 4095 succeeds
+  sts_hardware_interface::STSHardwareInterface hw3;
+  auto info3 = make_valid_position_motor_info();
+  info3.joints[0].parameters["position_center_steps"] = "4095";
+  EXPECT_EQ(hw3.on_init(info3), CallbackReturn::SUCCESS);
 }
 
 TEST(HardwareInterfaceInitTest, PositionCenterStepsInvalidValues) {
@@ -376,10 +382,10 @@ TEST(HardwareInterfaceInitTest, PositionCenterStepsInvalidValues) {
   info1.joints[0].parameters["position_center_steps"] = "5000";
   EXPECT_EQ(hw1.on_init(info1), CallbackReturn::ERROR);
 
-  // out of range (< -1)
+  // negative value
   sts_hardware_interface::STSHardwareInterface hw2;
   auto info2 = make_valid_position_motor_info();
-  info2.joints[0].parameters["position_center_steps"] = "-2";
+  info2.joints[0].parameters["position_center_steps"] = "-1";
   EXPECT_EQ(hw2.on_init(info2), CallbackReturn::ERROR);
 
   // non-numeric string


### PR DESCRIPTION
Replace fmod-based radians_to_raw_position with a unified formula using a configurable center parameter (raw encoder step that maps to 0 rad).

- Add position_center_steps joint parameter (0-4095, or -1 for default)
- Default center=4095 preserves backward-compatible [0, 2π] behavior
- Setting center=2048 enables [-π, +π) operation
- Fix roundtrip bug: 0 rad now correctly maps to step 4095 (was step 0)
- Gate parameter to position mode only; warn if set on velocity/PWM joints
- Add conversion and hardware interface unit tests for custom center

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable center position parameter for position-mode servo control, allowing custom mapping between raw encoder steps and joint angles. Defaults to legacy behavior (4095 steps = 0 radians) for backward compatibility.

* **Tests**
  * Updated and expanded conversion validation tests to verify custom center mappings and clamping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->